### PR TITLE
Commented out line that caused an error, stopping top100 to load

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,9 +277,9 @@
           if (isNaN(current)) {
             current = this.currentPage;
           }
-          if (isInit !== true) {
-            ga.getAll()[0].send('event', 'Data', 'Load', 'Ladder', current);
-          }
+          //if (isInit !== true) {
+          //  ga.getAll()[0].send('event', 'Data', 'Load', 'Ladder', current);
+          //}
           this.currentPage = current;
           const pageSize = 20;
           let offset = (current - 1) * pageSize;
@@ -290,7 +290,7 @@
           this.laddersData = apiData
         },
         async loadTopData() {
-          ga.getAll()[0].send('event', 'Data', 'Load', 'Top');
+          //ga.getAll()[0].send('event', 'Data', 'Load', 'Top');
           const offset = 0;
           const limit = 200;
           let apiData = await this.fetchAPI(offset, limit)


### PR DESCRIPTION
Since I don't know what `ga.getAll()[0].send(...)` is supposed to do, I don't know how to really fix it.

Since it seems that those lines to not have an effect to the display of the ladder, I simply commented those out, now top100 works aswell.